### PR TITLE
Add --display-ip option to allow forwarding X11 display traffic from Docker to a specified IP address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,20 @@ If you want to use the FVP GUI, you need to follow some additional steps on your
         xhost +
 
     If you need to set up a socat relay to forward X11 display traffic in a Colima + Docker environment, be sure to allow connections from localhost to ensure proper communication with your XQuartz server.
-
-        xhost + 127.0.0.1
+    ```sh
+    xhost + 127.0.0.1
+    #install and setup socat relay
+    brew install socat
+    socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\"
+    ```
 
 1.  Run model and check GUI is showing
 
         FVP_Corstone_SSE-300_Ethos-U55
 
-    If you need to forward display traffic to your Mac, pass your IP address using the `--display-ip` command-line parameter.
+    If you need to forward display traffic to your Mac, pass your IP address using the `--display-ip` command-line parameter. You can obtain your ip by calling `ipconfig getifaddr en0`.
+
+        FVP_Corstone_SSE-300_Ethos-U55 --display-ip 0.1.2.3
 
     <img src="docs/model-gui.png" width="200" alt="FVP model GUI" />
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,15 @@ If you want to use the FVP GUI, you need to follow some additional steps on your
 
         xhost +
 
+    If you need to set up a socat relay to forward X11 display traffic in a Colima + Docker environment, be sure to allow connections from localhost to ensure proper communication with your XQuartz server.
+
+        xhost + 127.0.0.1
+
 1.  Run model and check GUI is showing
 
         FVP_Corstone_SSE-300_Ethos-U55
+
+    If you need to forward display traffic to your Mac, pass your IP address using the `--display-ip` command-line parameter.
 
     <img src="docs/model-gui.png" width="200" alt="FVP model GUI" />
 

--- a/fvp.sh
+++ b/fvp.sh
@@ -5,8 +5,23 @@ DIRNAME="$(dirname "$(realpath "$0")")"
 
 source "${DIRNAME}/fvprc"
 
-FLAGS=("$@")
+FLAGS=()
 PORTS=()
+DISPLAY_IP="docker.for.mac.host.internal"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --display-ip)
+            DISPLAY_IP="$2"
+            shift 2
+            ;;
+        *)
+            FLAGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
 if [[ "${FLAGS[*]}" =~ "-I" || "${FLAGS[*]}" =~ "--iris-server" ]]; then
     PORTS+=("-p" "7100:7100")
     if [[ ! "${FLAGS[*]}" =~ "--print-port-number" && ! "${FLAGS[*]}" =~ "-p" ]]; then
@@ -26,7 +41,7 @@ docker run \
   --mount "type=bind,src=${HOME},dst=${HOME}" \
   --workdir "$(pwd)" \
   --env "ARMLM_CACHED_LICENSES_LOCATION=${HOME}/.armlm" \
-  --env DISPLAY=docker.for.mac.host.internal:0 \
+  --env DISPLAY=${DISPLAY_IP}:0 \
   --volume /tmp/.X11-unix:/tmp/.X11-unix \
   "fvp:${FVP_VERSION}" "${MODEL}" "${FLAGS[@]}"
 


### PR DESCRIPTION
This PR adds a `--display-ip` option to **fvp.sh** to make it easier to forward X11 display traffic when using FVPs with Colima and Docker on macOS.

# Why

Colima doesn’t support `docker.for.mac.host.internal`, so to get GUI apps (like FVPs) working with XQuartz, you usually need to set up a socat relay and manually pass your Mac’s IP. Rather than editing the script each time, I figured it’d be cleaner to add a command-line option for it.

# What’s Changed
- Added `--display-ip <ip>` to set the `DISPLAY` env variable
- Skips adding that option to the container’s runtime flags
- Keeps everything else working the same

# Notes
Tested with XQuartz and socat on Colima, and the display comes through nicely. Hope this makes it a little easier for others running into the same setup!
