### PR TITLE
Support controlling mounts using ENV vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ Once the setup has been completed one can run Fast Models as they are installed 
 
 Some restrictions still apply:
 
-- The users home directory is mapped into the Docker container. Hence, all files
-    accessed (application images, configuration files) must be stored in users home.
+- By default, only the current working directory is mounted into the Docker container. Hence, all files
+    accessed (application images, configuration files) must be stored in the current working directory
+    or its subdirectories, unless you specify a different mount directory using `FVP_MAC_PRIMARY_MOUNT_DIR`.
 
-- Fast Models require an activated User Based License. Typically, the license cache
-    is stored in `~/.armlm` on the host machine and mapped into the container as
-    part of the user home. Thus, the models running inside of the container reuse the
+- Fast Models require an activated User Based License. The license cache stored in `~/.armlm` on the host machine
+    is always mapped into the container. Thus, the models running inside of the container reuse the
     license activated on the host machine.
 
 ## Customization
@@ -141,27 +141,29 @@ The repository contains the following files:
 
 The script will always mount `~/.armlm/` inside the container in order to have access to licenses granted on your host. 
 
-By default, the entire home directory is also mounted in the container, providng read/write access to all files in your home directory.
+By default, the current working directory is mounted in the container, providing read/write access to files in that directory and its subdirectories.
 
 ### Mounting a specific directory
 
-If you want to mount only a specific directory instead of your entire home directory, set the `FVP_MAC_WORKDIR` ENV var. This improves performance and security by limiting access. 
+If you want to mount a different directory instead of the current working directory, set the `FVP_MAC_PRIMARY_MOUNT_DIR` environment variable:
 
 ```sh
-# Persistently configure the fvp.sh wrapper to bind mount `/Users/someone/my-project/` instead of the entire home directory
-# Note: The path must exist or the command will fail with an error
-export FVP_MAC_WORKDIR=/Users/someone/my-project/
+# Mount a specific directory
+export FVP_MAC_PRIMARY_MOUNT_DIR=/Users/someone/my-project/
 # - or -
-# Mount the current working directory for a single command
-FVP_MAC_WORKDIR=$(pwd) FVP_MPS2_Cortex-M3 --version
+# Mount a specific directory for a single command
+FVP_MAC_PRIMARY_MOUNT_DIR=/Users/someone/my-project/ FVP_MPS2_Cortex-M3 --version
 ```
 
-### Disabling all directory mounting
+### Setting the working directory
 
-If you don't need access to any files from your host system, you can disable all directory mounting for maximum security and performance. Set `FVP_DISABLE_HOME_MOUNT=true` to mount only the licence directory (`~/.armlm`).
+By default, the working directory inside the container is set to the mounted directory. You can override this with the `FVP_MAC_WORK_DIR` environment variable:
 
 ```sh
-# Only mount the licence directory, no other host directories
-export FVP_DISABLE_HOME_MOUNT=true
+# Set a different working directory inside the container
+export FVP_MAC_WORK_DIR=/path/to/workdir
+# - or -
+# Set working directory for a single command
+FVP_MAC_WORK_DIR=/path/to/workdir FVP_MPS2_Cortex-M3 --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Some restrictions still apply:
 
 - By default, only the current working directory is mounted into the Docker container. Hence, all files
     accessed (application images, configuration files) must be stored in the current working directory
-    or its subdirectories, unless you specify a different mount directory using `FVP_MAC_PRIMARY_MOUNT_DIR`.
+    or its subdirectories, unless you specify a different mount directory using `FVP_MOUNT_DIR`.
 
 - Fast Models require an activated User Based License. The license cache stored in `~/.armlm` on the host machine
     is always mapped into the container. Thus, the models running inside of the container reuse the
@@ -145,25 +145,25 @@ By default, the current working directory is mounted in the container, providing
 
 ### Mounting a specific directory
 
-If you want to mount a different directory instead of the current working directory, set the `FVP_MAC_PRIMARY_MOUNT_DIR` environment variable:
+If you want to mount a different directory instead of the current working directory, set the `FVP_MOUNT_DIR` environment variable:
 
 ```sh
 # Mount a specific directory
-export FVP_MAC_PRIMARY_MOUNT_DIR=/Users/someone/my-project/
+export FVP_MOUNT_DIR=/Users/someone/my-project/
 # - or -
 # Mount a specific directory for a single command
-FVP_MAC_PRIMARY_MOUNT_DIR=/Users/someone/my-project/ FVP_MPS2_Cortex-M3 --version
+FVP_MOUNT_DIR=/Users/someone/my-project/ FVP_MPS2_Cortex-M3 --version
 ```
 
 ### Setting the working directory
 
-By default, the working directory inside the container is set to the mounted directory. You can override this with the `FVP_MAC_WORK_DIR` environment variable:
+By default, the working directory inside the container is set to the mounted directory. You can override this with the `FVP_WORKDIR` environment variable:
 
 ```sh
 # Set a different working directory inside the container
-export FVP_MAC_WORK_DIR=/path/to/workdir
+export FVP_WORKDIR=/path/to/workdir
 # - or -
 # Set working directory for a single command
-FVP_MAC_WORK_DIR=/path/to/workdir FVP_MPS2_Cortex-M3 --version
+FVP_WORKDIR=/path/to/workdir FVP_MPS2_Cortex-M3 --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,14 +137,25 @@ The repository contains the following files:
     ┗ 📄 fvprc         The configuration file to customize default model version and package
 ```
 
-## Mounting additional paths into the FVP
+## Customizing mount behavior
 
-By default, only the `~./armlm` directory on the host is mounted in the container, which allows licenses granted on your host to be used inside the container.
+By default, the entire home directory is mounted in the container, which allows access to all files in your home directory and ensures licenses granted on your host are available inside the container.
+
+### Mounting additional paths
 
 If you want to mount an additional path on the host inside the container, set the `FVP_MAC_WORKDIR` ENV var.
 
 ```sh
 # Will cause the fvp.sh wrapper to bind mount `/Users/cool-guy/my-project/` to `/Users/cool-guy/my-project` inside the FVP container
 export FVP_MAC_WORKDIR=/Users/cool-guy/my-project/
+```
+
+### Disabling home directory mounting
+
+For security reasons, you may want to disable mounting the entire home directory. Set `FVP_DISABLE_HOME_MOUNT=true` to mount only the license directory (`~/.armlm`).
+
+```sh
+# Only mount the license directory, not the entire home directory
+export FVP_DISABLE_HOME_MOUNT=true
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Once the setup has been completed one can run Fast Models as they are installed 
 
 Some restrictions still apply:
 
-- By default, only the current working directory is mounted into the Docker container. Hence, all files
-    accessed (application images, configuration files) must be stored in the current working directory
+- By default, your home directory is mounted into the Docker container for file access. Hence, all files
+    accessed (application images, configuration files) must be stored in your home directory
     or its subdirectories, unless you specify a different mount directory using `FVP_MOUNT_DIR`.
 
 - Fast Models require an activated User Based License. The license cache stored in `~/.armlm` on the host machine
@@ -139,17 +139,15 @@ The repository contains the following files:
 
 ## Customising Docker Mounts
 
-FVPs running inside the Docker container need access to your application images and configuration files. The script automatically mounts `~/.armlm/` for license access, and by default mounts your current working directory for project files.
+By default, your entire home directory is mounted and the container starts in your current working directory.
 
-For projects stored elsewhere, use `FVP_MOUNT_DIR` to specify which directory to mount:
-
-```sh
-FVP_MOUNT_DIR=/Users/someone/my-project/ FVP_MPS2_Cortex-M3 --version
-```
-
-To set the working directory inside the container (independent of what's mounted), use `FVP_WORKDIR`:
+For better security and performance, use the `FVP_MOUNT_DIR` and `FVP_WORKDIR` ENV vars limit what's mounted:
 
 ```sh
-FVP_WORKDIR=/path/to/workdir FVP_MPS2_Cortex-M3 --version
+# Mount only current directory
+FVP_MOUNT_DIR=$(pwd) FVP_MPS2_Cortex-M3 --version
+
+# Mount project root but work in subdirectory
+FVP_MOUNT_DIR=/path/to/project FVP_WORKDIR=/path/to/project/build FVP_MPS2_Cortex-M3 --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -136,3 +136,15 @@ The repository contains the following files:
     ┣ 📄 fvp.sh        The wrapper script to launch a model executable inside a Docker container
     ┗ 📄 fvprc         The configuration file to customize default model version and package
 ```
+
+## Mounting additional paths into the FVP
+
+By default, only the `~./armlm` directory on the host is mounted in the container, which allows licenses granted on your host to be used inside the container.
+
+If you want to mount an additional path on the host inside the container, set the `FVP_MAC_WORKDIR` ENV var.
+
+```sh
+# Will cause the fvp.sh wrapper to bind mount `/Users/cool-guy/my-project/` to `/Users/cool-guy/my-project` inside the FVP container
+export FVP_MAC_WORKDIR=/Users/cool-guy/my-project/
+```
+

--- a/README.md
+++ b/README.md
@@ -137,25 +137,31 @@ The repository contains the following files:
     ┗ 📄 fvprc         The configuration file to customize default model version and package
 ```
 
-## Customizing mount behavior
+## Customising mount behaviour
 
-By default, the entire home directory is mounted in the container, which allows access to all files in your home directory and ensures licenses granted on your host are available inside the container.
+The script will always mount `~/.armlm/` inside the container in order to have access to licenses granted on your host. 
 
-### Mounting additional paths
+By default, the entire home directory is also mounted in the container, providng read/write access to all files in your home directory.
 
-If you want to mount an additional path on the host inside the container, set the `FVP_MAC_WORKDIR` ENV var.
+### Mounting a specific directory
+
+If you want to mount only a specific directory instead of your entire home directory, set the `FVP_MAC_WORKDIR` ENV var. This improves performance and security by limiting access. 
 
 ```sh
-# Will cause the fvp.sh wrapper to bind mount `/Users/cool-guy/my-project/` to `/Users/cool-guy/my-project` inside the FVP container
-export FVP_MAC_WORKDIR=/Users/cool-guy/my-project/
+# Persistently configure the fvp.sh wrapper to bind mount `/Users/someone/my-project/` instead of the entire home directory
+# Note: The path must exist or the command will fail with an error
+export FVP_MAC_WORKDIR=/Users/someone/my-project/
+# - or -
+# Mount the current working directory for a single command
+FVP_MAC_WORKDIR=$(pwd) FVP_MPS2_Cortex-M3 --version
 ```
 
-### Disabling home directory mounting
+### Disabling all directory mounting
 
-For security reasons, you may want to disable mounting the entire home directory. Set `FVP_DISABLE_HOME_MOUNT=true` to mount only the license directory (`~/.armlm`).
+If you don't need access to any files from your host system, you can disable all directory mounting for maximum security and performance. Set `FVP_DISABLE_HOME_MOUNT=true` to mount only the licence directory (`~/.armlm`).
 
 ```sh
-# Only mount the license directory, not the entire home directory
+# Only mount the licence directory, no other host directories
 export FVP_DISABLE_HOME_MOUNT=true
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,33 +137,19 @@ The repository contains the following files:
     ┗ 📄 fvprc         The configuration file to customize default model version and package
 ```
 
-## Customising mount behaviour
+## Customising Docker Mounts
 
-The script will always mount `~/.armlm/` inside the container in order to have access to licenses granted on your host. 
+FVPs running inside the Docker container need access to your application images and configuration files. The script automatically mounts `~/.armlm/` for license access, and by default mounts your current working directory for project files.
 
-By default, the current working directory is mounted in the container, providing read/write access to files in that directory and its subdirectories.
-
-### Mounting a specific directory
-
-If you want to mount a different directory instead of the current working directory, set the `FVP_MOUNT_DIR` environment variable:
+For projects stored elsewhere, use `FVP_MOUNT_DIR` to specify which directory to mount:
 
 ```sh
-# Mount a specific directory
-export FVP_MOUNT_DIR=/Users/someone/my-project/
-# - or -
-# Mount a specific directory for a single command
 FVP_MOUNT_DIR=/Users/someone/my-project/ FVP_MPS2_Cortex-M3 --version
 ```
 
-### Setting the working directory
-
-By default, the working directory inside the container is set to the mounted directory. You can override this with the `FVP_WORKDIR` environment variable:
+To set the working directory inside the container (independent of what's mounted), use `FVP_WORKDIR`:
 
 ```sh
-# Set a different working directory inside the container
-export FVP_WORKDIR=/path/to/workdir
-# - or -
-# Set working directory for a single command
 FVP_WORKDIR=/path/to/workdir FVP_MPS2_Cortex-M3 --version
 ```
 

--- a/fvp.sh
+++ b/fvp.sh
@@ -37,8 +37,8 @@ if ! docker image inspect "fvp:${FVP_VERSION}" >/dev/null 2>&1; then
 fi
 
 
-# Set mount_dir from environment variable or default to pwd
-mount_dir="${FVP_MOUNT_DIR:-$(pwd)}"
+# Set mount_dir from environment variable or default to home
+mount_dir="${FVP_MOUNT_DIR:-$HOME}"
 
 # Validate mount_dir exists and is a directory
 if [[ ! -d "$mount_dir" ]]; then
@@ -46,8 +46,8 @@ if [[ ! -d "$mount_dir" ]]; then
     exit 1
 fi
 
-# Set workdir from environment variable or default to mount_dir
-workdir="${FVP_WORKDIR:-$mount_dir}"
+# Set workdir from environment variable or default to pwd
+workdir="${FVP_WORKDIR:-$(pwd)}"
 
 # Validate workdir exists if it's a subdirectory of mount_dir
 if [[ "$workdir" == "$mount_dir"* && ! -d "$workdir" ]]; then

--- a/fvp.sh
+++ b/fvp.sh
@@ -39,8 +39,21 @@ fi
 
 # Set PRIMARY_MOUNT_DIR from environment variable or default to pwd
 PRIMARY_MOUNT_DIR="${FVP_MAC_PRIMARY_MOUNT_DIR:-$(pwd)}"
+
+# Validate PRIMARY_MOUNT_DIR exists and is a directory
+if [[ ! -d "$PRIMARY_MOUNT_DIR" ]]; then
+    echo "Error: PRIMARY_MOUNT_DIR '$PRIMARY_MOUNT_DIR' is not a valid directory" >&2
+    exit 1
+fi
+
 # Set WORKDIR from environment variable or default to PRIMARY_MOUNT_DIR
 WORKDIR="${FVP_MAC_WORK_DIR:-$PRIMARY_MOUNT_DIR}"
+
+# Validate WORKDIR exists if it's a subdirectory of PRIMARY_MOUNT_DIR
+if [[ "$WORKDIR" == "$PRIMARY_MOUNT_DIR"* && ! -d "$WORKDIR" ]]; then
+    echo "Error: WORKDIR '$WORKDIR' is not a valid directory" >&2
+    exit 1
+fi
 
 # Mount licenses
 MOUNTS=("--mount" "type=bind,src=${HOME}/.armlm/,dst=${HOME}/.armlm/")

--- a/fvp.sh
+++ b/fvp.sh
@@ -56,9 +56,10 @@ if [[ "$WORKDIR" == "$PRIMARY_MOUNT_DIR"* && ! -d "$WORKDIR" ]]; then
 fi
 
 # Mount licenses
-MOUNTS=("--mount" "type=bind,src=${HOME}/.armlm/,dst=${HOME}/.armlm/")
-# Primary mount
-MOUNTS+=("--mount" "type=bind,src=${PRIMARY_MOUNT_DIR}/,dst=${PRIMARY_MOUNT_DIR}/")
+MOUNTS=(
+    "--mount" "type=bind,src=${HOME}/.armlm/,dst=${HOME}/.armlm/"
+    "--mount" "type=bind,src=${PRIMARY_MOUNT_DIR}/,dst=${PRIMARY_MOUNT_DIR}/"
+)
 
 docker run \
   "${PORTS[@]}" \

--- a/fvp.sh
+++ b/fvp.sh
@@ -59,7 +59,7 @@ fi
 
 docker run \
   "${PORTS[@]}" \
-  "${MOUNTS[@]}"
+  "${MOUNTS[@]}" \
   --workdir "$(pwd)" \
   --env "ARMLM_CACHED_LICENSES_LOCATION=${HOME}/.armlm" \
   --env DISPLAY=${DISPLAY_IP}:0 \

--- a/fvp.sh
+++ b/fvp.sh
@@ -49,7 +49,12 @@ fi
 
 # Add the FVP_MAC_WORKDIR mount if the variable is set
 if [ -n "$FVP_MAC_WORKDIR" ]; then
-    MOUNTS+=("--mount" "type=bind,src=${FVP_MAC_WORKDIR},dst=${FVP_MAC_WORKDIR}")
+    if [ -d "$FVP_MAC_WORKDIR" ]; then
+        MOUNTS+=("--mount" "type=bind,src=${FVP_MAC_WORKDIR},dst=${FVP_MAC_WORKDIR}")
+    else
+        echo "Error: FVP_MAC_WORKDIR path '$FVP_MAC_WORKDIR' does not exist or is not a directory" >&2
+        exit 1
+    fi
 fi
 
 docker run \

--- a/fvp.sh
+++ b/fvp.sh
@@ -37,7 +37,15 @@ if ! docker image inspect "fvp:${FVP_VERSION}" >/dev/null 2>&1; then
 fi
 
 # Define the default mounts
-MOUNTS=("--mount" "type=bind,src=${HOME}/.armlm/,dst=${HOME}/.armlm/")
+MOUNTS=()
+
+# Mount home directory by default unless explicitly disabled
+if [ "$FVP_DISABLE_HOME_MOUNT" != "true" ]; then
+    MOUNTS+=("--mount" "type=bind,src=${HOME},dst=${HOME}")
+else
+    # If home mounting is disabled, still mount the license directory
+    MOUNTS+=("--mount" "type=bind,src=${HOME}/.armlm/,dst=${HOME}/.armlm/")
+fi
 
 # Add the FVP_MAC_WORKDIR mount if the variable is set
 if [ -n "$FVP_MAC_WORKDIR" ]; then
@@ -46,7 +54,7 @@ fi
 
 docker run \
   "${PORTS[@]}" \
-  "${MOUNTS[@]}" 
+  "${MOUNTS[@]}"
   --workdir "$(pwd)" \
   --env "ARMLM_CACHED_LICENSES_LOCATION=${HOME}/.armlm" \
   --env DISPLAY=${DISPLAY_IP}:0 \

--- a/fvp.sh
+++ b/fvp.sh
@@ -40,7 +40,7 @@ fi
 MOUNTS=()
 
 # Mount home directory by default unless explicitly disabled or custom workdir is set
-if [ "$FVP_DISABLE_HOME_MOUNT" != "true" ] && [ -z "$FVP_MAC_WORKDIR" ]; then
+if [[ "$FVP_DISABLE_HOME_MOUNT" != "true" ]] && [[ -z "$FVP_MAC_WORKDIR" ]]; then
     echo "Warning: FVPs-on-Mac container is mounting entire home directory. For improved performance and security, consider setting FVP_DISABLE_HOME_MOUNT=true or FVP_MAC_WORKDIR to limit mounted directories." >&2
     MOUNTS+=("--mount" "type=bind,src=${HOME},dst=${HOME}")
 else
@@ -51,14 +51,14 @@ fi
 WORKDIR="$(pwd)"
 
 # Handle custom workdir if specified
-if [ -n "$FVP_MAC_WORKDIR" ]; then
-    if [ ! -d "$FVP_MAC_WORKDIR" ]; then
+if [[ -n "$FVP_MAC_WORKDIR" ]]; then
+    if [[ ! -d "$FVP_MAC_WORKDIR" ]]; then
         echo "Error: FVP_MAC_WORKDIR path '$FVP_MAC_WORKDIR' does not exist or is not a directory" >&2
         exit 1
     fi
     MOUNTS+=("--mount" "type=bind,src=${FVP_MAC_WORKDIR},dst=${FVP_MAC_WORKDIR}")
     WORKDIR="$FVP_MAC_WORKDIR"
-elif [ "$FVP_DISABLE_HOME_MOUNT" == "true" ]; then
+elif [[ "$FVP_DISABLE_HOME_MOUNT" == "true" ]]; then
     WORKDIR="$HOME"
 else
     # Validate current directory is under $HOME when home is mounted

--- a/fvp.sh
+++ b/fvp.sh
@@ -37,34 +37,34 @@ if ! docker image inspect "fvp:${FVP_VERSION}" >/dev/null 2>&1; then
 fi
 
 
-# Set PRIMARY_MOUNT_DIR from environment variable or default to pwd
-PRIMARY_MOUNT_DIR="${FVP_MAC_PRIMARY_MOUNT_DIR:-$(pwd)}"
+# Set mount_dir from environment variable or default to pwd
+mount_dir="${FVP_MOUNT_DIR:-$(pwd)}"
 
-# Validate PRIMARY_MOUNT_DIR exists and is a directory
-if [[ ! -d "$PRIMARY_MOUNT_DIR" ]]; then
-    echo "Error: PRIMARY_MOUNT_DIR '$PRIMARY_MOUNT_DIR' is not a valid directory" >&2
+# Validate mount_dir exists and is a directory
+if [[ ! -d "$mount_dir" ]]; then
+    echo "Error: FVP_MOUNT_DIR '$mount_dir' is not a valid directory" >&2
     exit 1
 fi
 
-# Set WORKDIR from environment variable or default to PRIMARY_MOUNT_DIR
-WORKDIR="${FVP_MAC_WORK_DIR:-$PRIMARY_MOUNT_DIR}"
+# Set workdir from environment variable or default to mount_dir
+workdir="${FVP_WORKDIR:-$mount_dir}"
 
-# Validate WORKDIR exists if it's a subdirectory of PRIMARY_MOUNT_DIR
-if [[ "$WORKDIR" == "$PRIMARY_MOUNT_DIR"* && ! -d "$WORKDIR" ]]; then
-    echo "Error: WORKDIR '$WORKDIR' is not a valid directory" >&2
+# Validate workdir exists if it's a subdirectory of mount_dir
+if [[ "$workdir" == "$mount_dir"* && ! -d "$workdir" ]]; then
+    echo "Error: FVP_WORKDIR '$workdir' is not a valid directory" >&2
     exit 1
 fi
 
 # Mount licenses
 MOUNTS=(
     "--mount" "type=bind,src=${HOME}/.armlm/,dst=${HOME}/.armlm/"
-    "--mount" "type=bind,src=${PRIMARY_MOUNT_DIR}/,dst=${PRIMARY_MOUNT_DIR}/"
+    "--mount" "type=bind,src=${mount_dir}/,dst=${mount_dir}/"
 )
 
 docker run \
   "${PORTS[@]}" \
   "${MOUNTS[@]}" \
-  --workdir "$WORKDIR" \
+  --workdir "$workdir" \
   --env "ARMLM_CACHED_LICENSES_LOCATION=${HOME}/.armlm" \
   --env DISPLAY=${DISPLAY_IP}:0 \
   --volume /tmp/.X11-unix:/tmp/.X11-unix \

--- a/fvp.sh
+++ b/fvp.sh
@@ -36,9 +36,17 @@ if ! docker image inspect "fvp:${FVP_VERSION}" >/dev/null 2>&1; then
     "${DIRNAME}/build.sh"
 fi
 
+# Define the default mounts
+MOUNTS=("--mount" "type=bind,src=${HOME}/.armlm/,dst=${HOME}/.armlm/")
+
+# Add the FVP_MAC_WORKDIR mount if the variable is set
+if [ -n "$FVP_MAC_WORKDIR" ]; then
+    MOUNTS+=("--mount" "type=bind,src=${FVP_MAC_WORKDIR},dst=${FVP_MAC_WORKDIR}")
+fi
+
 docker run \
   "${PORTS[@]}" \
-  --mount "type=bind,src=${HOME},dst=${HOME}" \
+  "${MOUNTS[@]}" 
   --workdir "$(pwd)" \
   --env "ARMLM_CACHED_LICENSES_LOCATION=${HOME}/.armlm" \
   --env DISPLAY=${DISPLAY_IP}:0 \


### PR DESCRIPTION
By default, this repo mounts the entire user home directory with read & write permissions, which has security implications, increases the scope of the running image and can lead to poor performance, as bind-mounts on macOS are not particularly performant.

It also triggers this warning in Docker Desktop
<img width="444" alt="image" src="https://github.com/user-attachments/assets/d0b93a2c-54a2-4d41-8fcc-e5a1f7f93d5f" />

Change summary:
* Supports setting `FVP_MOUNT_DIR` to specify a mount directory, the default being $(pwd)
* Supports setting `FVP_WORKDIR` to specify control the working directory, defaulting to FVP_MOUNT_DIR

The behaviour in this feature was originally designed to support https://github.com/Arm-Debug/mdk-6-e2e-tests?tab=readme-ov-file#working-with-fvps-on-macos where it allowed us to run the test suite in working directories.
https://github.com/Arm-Debug/mdk-6-e2e-tests/blob/main/helpers/fixtures/vscode.ts#L18